### PR TITLE
feat(s3): add support for custom S3 endpoint and path-style addressing

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -53,6 +53,8 @@ export const config = {
         region: process.env.AWS_REGION,
         // binary files download host address.
         downloadUrl: process.env.AWS_DOWNLOAD_URL || process.env.DOWNLOAD_URL,
+        endpoint: process.env.S3_ENDPOINT, // optional - needed when working with S3-compatible services
+        forcePathStyle: toBool(process.env.S3_FORCE_PATH_STYLE), // optional - some S3 compatible services require path-style addressing
     },
     // Config for Aliyun OSS (https://www.aliyun.com/product/oss) when storageType value is "oss".
     oss: {

--- a/src/core/utils/storage.ts
+++ b/src/core/utils/storage.ts
@@ -84,7 +84,10 @@ function uploadFileToS3(key: string, filePath: string, logger: Logger): Promise<
             sessionToken: _.get(config, 's3.sessionToken'),
             region: _.get(config, 's3.region'),
         });
-        const s3 = new AWS.S3();
+        const s3 = new AWS.S3({
+            endpoint: _.get(config, 's3.endpoint'),
+            s3ForcePathStyle: _.get(config, 's3.forcePathStyle'),
+        });
         fs.readFile(filePath, (err, data) => {
             if (err) {
                 reject(new AppError(err));


### PR DESCRIPTION
- Introduced `S3_ENDPOINT` and `S3_FORCE_PATH_STYLE` environment variables in the configuration file to enable compatibility with S3-compatible services.
- Updated S3 client initialization in `storage.ts` to use custom endpoint and path-style addressing when required.